### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ New schema versions: 1.2, 0.2
 ### Added
 - New Project.menuButtons field (v0, v1)
 - New Filter enum items: SplitChannel, Colormap (v1)
+- New Layer.clip field (v1)
+- New Project.collectionLayout field (v1)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.1.1](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.1.0...v1.1.1)
+## [v1.2.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.1.0...v1.2.0)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ New schema versions: 1.2, 0.2
 - New Filter enum items: SplitChannel, Colormap (v1)
 - New Layer.clip field (v1)
 - New Project.collectionLayout field (v1)
-- LayerFilter values can be strings, booleans or numbers (v0, v1) 
+- LayerFilter values can be strings, booleans or numbers (v0, v1)
 - Allow list values: ExpectedHeader.cb_gr_list, ExpectedHeader.pie_list, ExpectedHeader.shape_gr_list (v1)
 - Fix default uid value for ExpectedHeader (v0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.1](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.1.0...v1.1.1)
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+
 ## [v1.1.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.0.2...v1.1.0)
 
 ### Added
@@ -20,21 +31,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.0.2](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.0.1...v1.0.2)
 
-### Changed
-- Renamed tissuumaps_schema.utils.current_schema_module to tissuumaps_schema.utils.CURRENT_SCHEMA_MODULE
-
 ### Added
 - Exported tissuumaps_schema.utils.CURRENT_SCHEMA_MODULE as tissuumaps_schema.current
 - Exported some additional functionality (e.g. get_major_version) via tissuumaps_schema.utils
 
+### Fixed
+
+### Changed
+- Renamed tissuumaps_schema.utils.current_schema_module to tissuumaps_schema.utils.CURRENT_SCHEMA_MODULE
+
+### Removed
+
 
 ## [v1.0.1](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.0.0...v1.0.1)
+
+### Added
 
 ### Fixed
 - Bug in `models` command
 
 ### Changed
 - Versioning scheme: PATCH indicates Python package bugfixes (removed PATCH from schema versioning)
+
+### Removed
 
 
 ## [v1.0.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v0.1.0...v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ New schema versions: 1.2, 0.2
 - New Filter enum items: SplitChannel, Colormap (v1)
 - New Layer.clip field (v1)
 - New Project.collectionLayout field (v1)
+- LayerFilter values can be strings, booleans or numbers (v0, v1) 
+- Allow list values: ExpectedHeader.cb_gr_list, ExpectedHeader.pie_list, ExpectedHeader.shape_gr_list (v1)
+- Fix default uid value for ExpectedHeader (v0)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.2.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.1.0...v1.2.0)
 
+New schema versions: 1.2, 0.2
+
 ### Added
+- New Project.menuButtons field (v0, v1)
+- New Filter enum items: SplitChannel, Colormap (v1)
 
 ### Fixed
 
 ### Changed
+- Allow extra fields in v0
+- Allow dictionary values: ExpectedHeader.cb_gr_dict, ExpectedHeader.pie_dict, ExpectedHeader.shape_gr_dict (v1)
 
 ### Removed
 
 
 ## [v1.1.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v1.0.2...v1.1.0)
+
+New schema versions: 1.1
 
 ### Added
 - New field `ExpectedHeader.stroke_width`
@@ -57,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [v1.0.0](https://github.com/TissUUmaps/TissUUmaps-schema/compare/v0.1.0...v1.0.0)
+
+New schema versions: 1.0, 0.1
 
 ### Added
 - Schema version 0.1.0 ("expectedCSV" format of an EOL TissUUmaps version)

--- a/tissuumaps_schema/v00/base.py
+++ b/tissuumaps_schema/v00/base.py
@@ -2,7 +2,7 @@ from pydantic import ConfigDict, Field
 
 from ..base import RootSchemaBaseModel, SchemaBaseModel
 
-VERSION = "0.1"
+VERSION = "0.2"
 
 
 class SchemaBaseModelV00(SchemaBaseModel):

--- a/tissuumaps_schema/v00/base.py
+++ b/tissuumaps_schema/v00/base.py
@@ -1,9 +1,14 @@
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
-from ..base import RootSchemaBaseModel
+from ..base import RootSchemaBaseModel, SchemaBaseModel
 
 VERSION = "0.1"
 
 
+class SchemaBaseModelV00(SchemaBaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
 class RootSchemaBaseModelV00(RootSchemaBaseModel):
+    model_config = ConfigDict(extra="allow")
     schema_version: str = Field(default=VERSION, alias="schemaVersion")

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -256,6 +256,11 @@ class DropdownOption(SchemaBaseModelV00):
     )
 
 
+class menuButton(SchemaBaseModelV00):
+    text: str = Field(description="Text of the menu item.")
+    url: str = Field(description="Url of the menu item.")
+
+
 class MarkerFile(SchemaBaseModelV00):
     title: str = Field(description="Name of marker button.")
     comment: Optional[str] = Field(
@@ -438,5 +443,10 @@ class Project(RootSchemaBaseModelV00):
         default=None,
         alias="backgroundColor",
         description="Background color of the viewer.",
+    )
+    menu_buttons: Optional[list[menuButton]] = Field(
+        default=None,
+        alias="menuButtons",
+        description="List of menu items to be added to the menu bar.",        
     )
     settings: list[Setting] = []

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -3,8 +3,7 @@ from typing import Any, Optional, Union
 
 from pydantic import ConfigDict, Field
 
-from ..base import SchemaBaseModel
-from .base import RootSchemaBaseModelV00
+from .base import RootSchemaBaseModelV00, SchemaBaseModelV00
 
 
 class ColorScale(str, Enum):
@@ -110,7 +109,7 @@ class Shape(str, Enum):
     ARROW = "arrow"
 
 
-class Layer(SchemaBaseModel):
+class Layer(SchemaBaseModelV00):
     name: str = Field(description="Name of the image layer")
     tile_source: str = Field(
         alias="tileSource",
@@ -132,12 +131,12 @@ class Layer(SchemaBaseModel):
     scale: Optional[float] = Field(default=None, description="Scale of the image.")
 
 
-class LayerFilter(SchemaBaseModel):
+class LayerFilter(SchemaBaseModelV00):
     name: Filter = Field(description="Filter name.")
     value: str = Field(description="Filter parameter.")
 
 
-class BoundingBox(SchemaBaseModel):
+class BoundingBox(SchemaBaseModelV00):
     x: float = Field(
         description="Left coordinate of the bounding box in viewport coordinate."
     )
@@ -152,13 +151,13 @@ class BoundingBox(SchemaBaseModel):
     )
 
 
-class Setting(SchemaBaseModel):
+class Setting(SchemaBaseModelV00):
     module: str = Field(description="Module where the function or property lies.")
     function: str = Field(description="Function or property of the given module.")
     value: Any
 
 
-class ExpectedCSV(SchemaBaseModel):
+class ExpectedCSV(SchemaBaseModelV00):
     x_col: str = Field(alias="X_col")
     y_col: str = Field(alias="Y_col")
     key: str = "letters"
@@ -169,7 +168,7 @@ class ExpectedCSV(SchemaBaseModel):
     scale: Optional[str] = None
 
 
-class ExpectedRadios(SchemaBaseModel):
+class ExpectedRadios(SchemaBaseModelV00):
     cb_col: bool = Field(
         default=False,
         description="If markers should be colored by data in CSV column.",
@@ -246,7 +245,7 @@ class ExpectedRadios(SchemaBaseModel):
     )
 
 
-class DropdownOption(SchemaBaseModel):
+class DropdownOption(SchemaBaseModelV00):
     # We use extra="allow" here because we want to allow extra keys in the config
     # dictionary. This is because we want to allow the user to add custom keys to the
     # dropdown options, e.g. "expectedHeader.cb_col".
@@ -257,7 +256,7 @@ class DropdownOption(SchemaBaseModel):
     )
 
 
-class MarkerFile(SchemaBaseModel):
+class MarkerFile(SchemaBaseModelV00):
     title: str = Field(description="Name of marker button.")
     comment: Optional[str] = Field(
         default=None,
@@ -315,7 +314,7 @@ class MarkerFile(SchemaBaseModel):
     )
 
 
-class RegionFile(SchemaBaseModel):
+class RegionFile(SchemaBaseModelV00):
     title: str = Field(description="Name of region button.")
     comment: Optional[str] = Field(
         default=None,

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -257,7 +257,9 @@ class DropdownOption(SchemaBaseModelV00):
 
 
 class menuButton(SchemaBaseModelV00):
-    text: str = Field(description="Text of the menu item.")
+    text: Union[list[str], str] = Field(
+        description=("Text of the menu item. If list, then a nested menu is created.")
+    )
     url: str = Field(description="Url of the menu item.")
 
 

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -447,6 +447,6 @@ class Project(RootSchemaBaseModelV00):
     menu_buttons: Optional[list[menuButton]] = Field(
         default=None,
         alias="menuButtons",
-        description="List of menu items to be added to the menu bar.",        
+        description="List of menu items to be added to the menu bar.",
     )
     settings: list[Setting] = []

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -133,7 +133,7 @@ class Layer(SchemaBaseModelV00):
 
 class LayerFilter(SchemaBaseModelV00):
     name: Filter = Field(description="Filter name.")
-    value: Union[str, bool] = Field(description="Filter parameter.")
+    value: Union[str, bool, int, float] = Field(description="Filter parameter.")
 
 
 class BoundingBox(SchemaBaseModelV00):

--- a/tissuumaps_schema/v00/project.py
+++ b/tissuumaps_schema/v00/project.py
@@ -133,7 +133,7 @@ class Layer(SchemaBaseModelV00):
 
 class LayerFilter(SchemaBaseModelV00):
     name: Filter = Field(description="Filter name.")
-    value: str = Field(description="Filter parameter.")
+    value: Union[str, bool] = Field(description="Filter parameter.")
 
 
 class BoundingBox(SchemaBaseModelV00):

--- a/tissuumaps_schema/v01/base.py
+++ b/tissuumaps_schema/v01/base.py
@@ -2,7 +2,7 @@ from pydantic import Field
 
 from ..base import RootSchemaBaseModel
 
-VERSION = "1.1"
+VERSION = "1.2"
 
 
 class RootSchemaBaseModelV01(RootSchemaBaseModel):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -115,8 +115,8 @@ class Shape(str, Enum):
 
 
 class LayoutAxis(str, Enum):
-    HORIZONTAL = "horizontally"
-    VERTICAL = "vertically"
+    HORIZONTALLY = "horizontally"
+    VERTICALLY = "vertically"
 
 
 class CollectionLayout(SchemaBaseModel):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -699,7 +699,9 @@ class Project(RootSchemaBaseModelV01):
                                 "`HTMLElementUtils._colorsperbarcode` must be JSON"
                             )
                     else:
-                        assert isinstance(value_value, dict, list)
+                        assert isinstance(value_value, dict) or isinstance(
+                            value_value, list
+                        )
                     expected_radios_data["cb_gr"] = True
                     expected_radios_data["cb_gr_rand"] = False
                     expected_radios_data["cb_gr_key"] = False

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -587,7 +587,7 @@ class Project(RootSchemaBaseModelV01):
     menu_buttons: Optional[list[menuButton]] = Field(
         default=None,
         alias="menuButtons",
-        description="List of menu items to be added to the menu bar.",        
+        description="List of menu items to be added to the menu bar.",
     )
     settings: list[Setting] = []
 

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -396,7 +396,9 @@ class DropdownOption(SchemaBaseModel):
 
 
 class menuButton(SchemaBaseModel):
-    text: str = Field(description="Text of the menu item.")
+    text: Union[list[str], str] = Field(
+        description=("Text of the menu item. If list, then a nested menu is created.")
+    )
     url: str = Field(description="Url of the menu item.")
 
 

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -93,6 +93,8 @@ class Filter(str, Enum):
     THRESHOLD = "Threshold"
     EROSION = "Erosion"
     DILATION = "Dilation"
+    SPLIT_CHANNEL = "SplitChannel"
+    COLORMAP = "Colormap"
 
 
 class Shape(str, Enum):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -740,7 +740,7 @@ class Project(RootSchemaBaseModelV01):
                                 "`HTMLElementUtils._colorsperbarcode` must be JSON"
                             )
                     else:
-                        assert LayoutAxis isinstance(value_value, (dict, list))
+                        assert isinstance(value_value, (dict, list))
                     expected_radios_data["cb_gr"] = True
                     expected_radios_data["cb_gr_rand"] = False
                     expected_radios_data["cb_gr_key"] = False

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -740,9 +740,7 @@ class Project(RootSchemaBaseModelV01):
                                 "`HTMLElementUtils._colorsperbarcode` must be JSON"
                             )
                     else:
-                        assert isinstance(value_value, dict) or isinstance(
-                            value_value, list
-                        )
+                        assert LayoutAxis isinstance(value_value, (dict, list))
                     expected_radios_data["cb_gr"] = True
                     expected_radios_data["cb_gr_rand"] = False
                     expected_radios_data["cb_gr_key"] = False

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -114,6 +114,17 @@ class Shape(str, Enum):
     ARROW = "arrow"
 
 
+class LayerClip(SchemaBaseModel):
+    x: float = Field(
+        description="Left coordinate of the clip in image pixel coordinate."
+    )
+    y: float = Field(
+        description="Top coordinate of the clip in image pixel coordinate."
+    )
+    w: float = Field(description="Width of the clip in image pixel coordinate.")
+    h: float = Field(description="Height of the clip in image pixel coordinate.")
+
+
 class Layer(SchemaBaseModel):
     name: str = Field(description="Name of the image layer")
     tile_source: str = Field(
@@ -134,6 +145,13 @@ class Layer(SchemaBaseModel):
         description="Flip the image horizontally.",
     )
     scale: Optional[float] = Field(default=None, description="Scale of the image.")
+    clip: Optional[LayerClip] = Field(
+        default=None,
+        description=(
+            "Bounding box used to clip image in image pixel coordinate. If not "
+            "specified, the whole image is shown."
+        ),
+    )
 
 
 class LayerFilter(SchemaBaseModel):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -156,7 +156,7 @@ class Layer(SchemaBaseModel):
 
 class LayerFilter(SchemaBaseModel):
     name: Filter = Field(description="Filter name.")
-    value: Union[str, bool] = Field(description="Filter parameter.")
+    value: Union[str, bool, int, float] = Field(description="Filter parameter.")
 
 
 class BoundingBox(SchemaBaseModel):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -699,7 +699,7 @@ class Project(RootSchemaBaseModelV01):
                                 "`HTMLElementUtils._colorsperbarcode` must be JSON"
                             )
                     else:
-                        assert isinstance(value_value, dict)
+                        assert isinstance(value_value, dict, list)
                     expected_radios_data["cb_gr"] = True
                     expected_radios_data["cb_gr_rand"] = False
                     expected_radios_data["cb_gr_key"] = False

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -611,9 +611,9 @@ class Project(RootSchemaBaseModelV01):
             if "expectedRadios" not in marker_file_data:
                 marker_file_data["expectedRadios"] = {}
             expected_radios_data = marker_file_data["expectedRadios"]
-            # uid: "uniquetab" --> None
-            if marker_file_data.get("uid") == "uniquetab":
-                marker_file_data["uid"] = None
+            # uid: None --> "uniquetab"
+            if marker_file_data.get("uid") is None:
+                marker_file_data["uid"] = "uniquetab"
             # infer name from title
             title_value: str = marker_file_data["title"]
             marker_file_data["name"] = title_value.replace("Download", "").strip()

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -114,6 +114,38 @@ class Shape(str, Enum):
     ARROW = "arrow"
 
 
+class LayoutAxis(str, Enum):
+    HORIZONTAL = "horizontally"
+    VERTICAL = "vertically"
+
+
+class CollectionLayout(SchemaBaseModel):
+    immediately: Optional[bool] = Field(
+        default=False,
+        description="Whether to animate to the new arrangement.",
+    )
+    layout: Optional[LayoutAxis] = Field(
+        default=None,
+        description="See collectionLayout in OpenSeadragon.Options.",
+    )
+    rows: Optional[int] = Field(
+        default=None,
+        description="See collectionRows in OpenSeadragon.Options.",
+    )
+    columns: Optional[int] = Field(
+        default=None,
+        description="See collectionColumns in OpenSeadragon.Options.",
+    )
+    tileSize: Optional[float] = Field(
+        default=None,
+        description="See collectionTileSize in OpenSeadragon.Options.",
+    )
+    tileMargin: Optional[float] = Field(
+        default=None,
+        description="See collectionTileMargin in OpenSeadragon.Options.",
+    )
+
+
 class LayerClip(SchemaBaseModel):
     x: float = Field(
         description="Left coordinate of the clip in image pixel coordinate."
@@ -534,6 +566,15 @@ class Project(RootSchemaBaseModelV01):
             "Mode defining how image layers will be merged (composited) with each "
             "other. Valid string values are 'source-over' and 'lighter', which "
             "correspond to 'Channels' and 'Composite' in the GUI."
+        ),
+    )
+    collection_layout: Optional[CollectionLayout] = Field(
+        default=None,
+        alias="collectionLayout",
+        description=(
+            "Options to be passed to OpenSeadragon arrange method when in collection"
+            "mode. See "
+            "(https://openseadragon.github.io/docs/OpenSeadragon.World.html#arrange)"
         ),
     )
     mpp: Optional[float] = Field(

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -182,7 +182,7 @@ class ExpectedHeader(SchemaBaseModel):
             "hexadecimal RGB colors in format '#ff0000'."
         ),
     )
-    cb_gr_dict: str = Field(
+    cb_gr_dict: Union[str, dict[str, Any]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping group keys to "
@@ -218,7 +218,7 @@ class ExpectedHeader(SchemaBaseModel):
             "characters in the CSV column data."
         ),
     )
-    pie_dict: str = Field(
+    pie_dict: Union[str, dict[str, Any]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping pie chart sector "
@@ -237,7 +237,7 @@ class ExpectedHeader(SchemaBaseModel):
         default="cross",
         description="Name or index of a single fixed shape to be used for all markers.",
     )
-    shape_gr_dict: str = Field(
+    shape_gr_dict: Union[str, dict[str, Any]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping group keys to "
@@ -657,15 +657,17 @@ class Project(RootSchemaBaseModelV01):
                     module_value == "HTMLElementUtils"
                     and function_value in ("_colorsperiter", "_colorsperbarcode")
                 ):
-                    assert isinstance(value_value, str)
-                    try:
-                        json.loads(value_value)
-                    except json.JSONDecodeError:
-                        raise AssertionError(
-                            "The setting values of `markerUtils._colorsperkey`, "
-                            "`HTMLElementUtils._colorsperiter` and "
-                            "`HTMLElementUtils._colorsperbarcode` must be JSON strings"
-                        )
+                    if isinstance(value_value, str):
+                        try:
+                            json.loads(value_value)
+                        except json.JSONDecodeError:
+                            raise AssertionError(
+                                "The setting values of `markerUtils._colorsperkey`, "
+                                "`HTMLElementUtils._colorsperiter` and "
+                                "`HTMLElementUtils._colorsperbarcode` must be JSON"
+                            )
+                    else:
+                        assert isinstance(value_value, dict)
                     expected_radios_data["cb_gr"] = True
                     expected_radios_data["cb_gr_rand"] = False
                     expected_radios_data["cb_gr_key"] = False

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -184,7 +184,7 @@ class ExpectedHeader(SchemaBaseModel):
             "hexadecimal RGB colors in format '#ff0000'."
         ),
     )
-    cb_gr_dict: Union[str, dict[str, Any]] = Field(
+    cb_gr_dict: Union[str, dict[str, Any], list[str]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping group keys to "
@@ -220,7 +220,7 @@ class ExpectedHeader(SchemaBaseModel):
             "characters in the CSV column data."
         ),
     )
-    pie_dict: Union[str, dict[str, Any]] = Field(
+    pie_dict: Union[str, dict[str, Any], list[str]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping pie chart sector "
@@ -239,7 +239,7 @@ class ExpectedHeader(SchemaBaseModel):
         default="cross",
         description="Name or index of a single fixed shape to be used for all markers.",
     )
-    shape_gr_dict: Union[str, dict[str, Any]] = Field(
+    shape_gr_dict: Union[str, dict[str, Any], list[str]] = Field(
         default="",
         description=(
             "JSON string specifying a custom dictionary for mapping group keys to "

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -138,7 +138,7 @@ class Layer(SchemaBaseModel):
 
 class LayerFilter(SchemaBaseModel):
     name: Filter = Field(description="Filter name.")
-    value: str = Field(description="Filter parameter.")
+    value: Union[str, bool] = Field(description="Filter parameter.")
 
 
 class BoundingBox(SchemaBaseModel):

--- a/tissuumaps_schema/v01/project.py
+++ b/tissuumaps_schema/v01/project.py
@@ -395,6 +395,11 @@ class DropdownOption(SchemaBaseModel):
     )
 
 
+class menuButton(SchemaBaseModel):
+    text: str = Field(description="Text of the menu item.")
+    url: str = Field(description="Url of the menu item.")
+
+
 class MarkerFile(SchemaBaseModel):
     title: str = Field(description="Name of marker button.")
     comment: Optional[str] = Field(
@@ -578,6 +583,11 @@ class Project(RootSchemaBaseModelV01):
         default=None,
         alias="backgroundColor",
         description="Background color of the viewer.",
+    )
+    menu_buttons: Optional[list[menuButton]] = Field(
+        default=None,
+        alias="menuButtons",
+        description="List of menu items to be added to the menu bar.",        
     )
     settings: list[Setting] = []
 


### PR DESCRIPTION
- [x] Allow extra fields in v0
- [x] Allow dictionaries and lists for: `ExpectedHeader.cb_gr_dict`, `ExpectedHeader.pie_dict`, `ExpectedHeader.shape_gr_dict` (v1 only)
- [x] Add `SplitChannel` and `Colormap` to `Filter` enum in v1
- [x] Add a `menuButtons` field to both v0 and v1
- [x] Bump v0.1 to v0.2 and v1.1 to v1.2
- [x] Fix default uid value for ExpectedHeader in v0
- [x] Allow strings, booleans or numbers for LayerFilter values
- [x] Add Project.collectionLayout field
- [x] Add Layer.clip field
- [x] Update changelog